### PR TITLE
WebViewブロック

### DIFF
--- a/src/components/InAppBrowserPage.tsx
+++ b/src/components/InAppBrowserPage.tsx
@@ -1,0 +1,149 @@
+import { FC, useState } from "react";
+import { Button } from "@heroui/react";
+import { PiCopy, PiArrowUpRight, PiDesktop } from "react-icons/pi";
+import { useInAppBrowser } from "@/hooks/useInAppBrowser";
+import Image from "next/image";
+
+export const InAppBrowserPage: FC = () => {
+  const [copied, setCopied] = useState(false);
+  const currentUrl = typeof window !== "undefined" ? window.location.href : "";
+
+  const handleCopyLink = async () => {
+    try {
+      await navigator.clipboard.writeText(currentUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("リンクのコピーに失敗しました:", error);
+    }
+  };
+
+  const handleOpenInChrome = () => {
+    const currentUrl = window.location.href;
+    try {
+      // iOS Safariの場合
+      if (
+        navigator.userAgent.includes("iPhone") ||
+        navigator.userAgent.includes("iPad")
+      ) {
+        window.open(currentUrl, "_blank");
+      } else {
+        // Androidやその他の場合
+        const newWindow = window.open(currentUrl, "_blank");
+        if (
+          !newWindow ||
+          newWindow.closed ||
+          typeof newWindow.closed === "undefined"
+        ) {
+          window.location.href = currentUrl;
+        }
+      }
+    } catch (error) {
+      console.error("外部ブラウザで開く際にエラーが発生しました:", error);
+      window.location.href = currentUrl;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">
+      <div className="max-w-md w-full bg-white rounded-2xl shadow-xl p-8 text-center">
+        {/* ロゴ */}
+        <div className="mb-8">
+          <Image
+            src="/borderless_logotype.png"
+            alt="Borderless"
+            width={200}
+            height={40}
+            className="mx-auto"
+          />
+        </div>
+
+        {/* メインコンテンツ */}
+        <div className="space-y-6">
+          <h1 className="text-2xl font-bold text-gray-900">
+            Chromeでこのページを開く
+          </h1>
+
+          <p className="text-gray-600 leading-relaxed">
+            このデバイスでBorderlessを使用するには、Chromeモバイルブラウザでこのページを参照してください。すでにお持ちの場合はこちらをクリックしてください。
+          </p>
+
+          {/* Chromeで開くボタン */}
+          <Button
+            size="lg"
+            color="primary"
+            className="w-full bg-blue-600 text-white font-semibold"
+            startContent={<PiArrowUpRight size={20} />}
+            onPress={handleOpenInChrome}
+          >
+            Chromeで開く
+          </Button>
+
+          {/* Chromeがインストールされていない場合の手順 */}
+          <div className="bg-gray-50 rounded-xl p-6 space-y-4">
+            <h2 className="text-lg font-semibold text-gray-900">
+              このデバイスにChromeがインストールされていませんか？
+            </h2>
+
+            <div className="space-y-4 text-left">
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
+                  1
+                </div>
+                <div className="flex-1">
+                  <p className="text-gray-700 mb-2">
+                    ページのリンクをコピーします
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="bordered"
+                    startContent={<PiCopy size={16} />}
+                    onPress={handleCopyLink}
+                    className="text-blue-600 border-blue-600"
+                  >
+                    {copied ? "コピー完了！" : "リンクをコピーする"}
+                  </Button>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
+                  2
+                </div>
+                <div className="flex-1">
+                  <p className="text-gray-700">
+                    Chromeモバイルブラウザをインストールします
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex items-start gap-3">
+                <div className="flex-shrink-0 w-6 h-6 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-bold">
+                  3
+                </div>
+                <div className="flex-1">
+                  <p className="text-gray-700">
+                    検索バーにリンクを貼り付けます
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* ノートパソコンの案内 */}
+          <div className="bg-yellow-50 rounded-xl p-6 space-y-3">
+            <div className="flex items-center justify-center gap-2 text-yellow-800">
+              <PiDesktop size={20} />
+              <h3 className="text-lg font-semibold">
+                ノートパソコンをお持ちですか？
+              </h3>
+            </div>
+            <p className="text-yellow-700 text-sm">
+              最適な環境で使用するには、このページをノートパソコンデスクトップパソコンで開いてください
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/estuary/EstuaryContainer.tsx
+++ b/src/components/estuary/EstuaryContainer.tsx
@@ -18,6 +18,8 @@ import PaymentPage from "./PaymentPage";
 import { useGoogleAuth } from "@/hooks/useGoogleAuth";
 import { useIsCompanyMember } from "@/hooks/useMember";
 import { useSignOut } from "@/hooks/useSignOut";
+import { InAppBrowserPage } from "../InAppBrowserPage";
+import { useInAppBrowser } from "@/hooks/useInAppBrowser";
 
 export const EstuaryContainer: FC = () => {
   const { t } = useTranslation("estuary");
@@ -32,6 +34,7 @@ export const EstuaryContainer: FC = () => {
     account?.address
   );
   const { signOut } = useSignOut();
+  const { isInAppBrowser } = useInAppBrowser();
   useEffect(() => {
     if (!me?.isLogin || !account?.address) {
       if (page !== 0) {
@@ -54,7 +57,15 @@ export const EstuaryContainer: FC = () => {
     isMemberLoading,
     isMember,
     page,
+    router.pathname,
+    setPage,
+    signOut,
   ]);
+  // アプリ内ブラウザで開かれた場合は専用ページを表示
+  if (isInAppBrowser) {
+    return <InAppBrowserPage />;
+  }
+
   return (
     <div className="w-full h-svh flex flex-col items-center justify-center gap-4">
       <div className="relative w-full max-w-[35rem] h-[720px] bg-stone-50 rounded-3xl shadow-xl flex flex-col justify-center border-1 border-slate-200 overflow-y-scroll">

--- a/src/hooks/useInAppBrowser.ts
+++ b/src/hooks/useInAppBrowser.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect } from "react";
+
+interface InAppBrowserInfo {
+  isInAppBrowser: boolean;
+  browserType: string | null;
+  canOpenExternal: boolean;
+}
+
+export const useInAppBrowser = (): InAppBrowserInfo => {
+  const [browserInfo, setBrowserInfo] = useState<InAppBrowserInfo>({
+    isInAppBrowser: false,
+    browserType: null,
+    canOpenExternal: false,
+  });
+
+  useEffect(() => {
+    const detectInAppBrowser = () => {
+      const userAgent = navigator.userAgent;
+      let isInAppBrowser = false;
+      let browserType: string | null = null;
+      let canOpenExternal = false;
+
+      // LINE
+      if (/Line/i.test(userAgent)) {
+        isInAppBrowser = true;
+        browserType = "LINE";
+        canOpenExternal = true;
+      }
+      // Facebook
+      else if (/FB/i.test(userAgent)) {
+        isInAppBrowser = true;
+        browserType = "Facebook";
+        canOpenExternal = true;
+      }
+      // Instagram
+      else if (/Instagram/i.test(userAgent)) {
+        isInAppBrowser = true;
+        browserType = "Instagram";
+        canOpenExternal = true;
+      }
+
+      setBrowserInfo({
+        isInAppBrowser,
+        browserType,
+        canOpenExternal,
+      });
+    };
+
+    detectInAppBrowser();
+  }, []);
+
+  return browserInfo;
+};


### PR DESCRIPTION
## 概要

- Facebook、Instagram、LINEのアプリ内ブラウザで開かれた場合に専用ページを表示する機能

---

## 工程

1. アプリ内ブラウザ検出フックの作成
2. 専用ページコンポーネントの開発
3. EstuaryContainerへの統合

---

## 進捗

- [x] 1. アプリ内ブラウザ検出フックの作成
- [x] 2. 専用ページコンポーネントの開発
- [x] 3. EstuaryContainerへの統合

---

## 確認事項

- Facebook、Instagram、LINEのアプリ内ブラウザで開かれた場合に専用ページが表示されることを確認
- 通常のブラウザでは従来通りのページが表示されることを確認
- Chromeで開くボタンが正常に動作することを確認
- リンクコピー機能が正常に動作することを確認

---

## その他

- [x] コンフリクトなしチェック


### 実装内容

**新規作成ファイル:**
- `src/hooks/useInAppBrowser.ts` - アプリ内ブラウザ検出フック
- `src/components/InAppBrowserPage.tsx` - 専用ページコンポーネント

**修正ファイル:**
- `src/components/estuary/EstuaryContainer.tsx` - アプリ内ブラウザ検出機能の統合


### 機能詳細

- Facebook、Instagram、LINEのアプリ内ブラウザを検出
- 検出された場合は専用ページを表示
- Chromeで開くボタンで外部ブラウザに遷移
- リンクコピー機能でURLをクリップボードにコピー
- 手順説明とデスクトップ案内を表示